### PR TITLE
feature: Implement AddNotification command handler and repository method

### DIFF
--- a/src/Notification/Notification.Core/UseCases/Notification/AddNotification/AddNotificationCommand.cs
+++ b/src/Notification/Notification.Core/UseCases/Notification/AddNotification/AddNotificationCommand.cs
@@ -1,0 +1,28 @@
+﻿using MediatR;
+using Planorama.Notification.Core.Enums;
+using System;
+
+namespace Planorama.Notification.Core.UseCases.Notification.AddNotification
+{
+    public class AddNotificationCommand : IRequest
+    {
+        public Guid UserId { get; set; }
+        public string UserEmail { get; set; }
+        public string Title { get; set; }
+        public NotificationType Type { get; set; }
+        public string Content { get; set; }
+        public Guid ReferenceId { get; set; }
+        public string DeleteId { get; set; }
+
+        public AddNotificationCommand(Guid userId, string userEmail, string title, NotificationType type, string content, Guid referenceId, string deleteId)
+        {
+            UserId = userId;
+            UserEmail = userEmail;
+            Title = title;
+            Type = type;
+            Content = content;
+            ReferenceId = referenceId;
+            DeleteId = deleteId;
+        }
+    }
+}

--- a/src/Notification/Notification.Core/UseCases/Notification/AddNotification/AddNotificationCommandHandler.cs
+++ b/src/Notification/Notification.Core/UseCases/Notification/AddNotification/AddNotificationCommandHandler.cs
@@ -1,0 +1,40 @@
+﻿using MediatR;
+using Planorama.Integration.MessageBroker.Core.Abstraction;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Planorama.Notification.Core.UseCases.Notification.AddNotification
+{
+    public class AddNotificationCommandHandler : IRequestHandler<AddNotificationCommand>
+    {
+        private readonly IAddNotificationRepository addNotificationRepository;
+        private readonly IEventBus eventBus;
+
+        public AddNotificationCommandHandler(IAddNotificationRepository addNotificationRepository, IEventBus eventBus)
+        {
+            this.addNotificationRepository = addNotificationRepository;
+            this.eventBus = eventBus;
+        }
+
+        public async Task Handle(AddNotificationCommand request, CancellationToken cancellationToken)
+        {
+            var notification = new Models.Notification()
+            {
+                Id = Guid.NewGuid(),
+                DateCreatedUtc = DateTime.UtcNow,
+                UserId = request.UserId,
+                UserEmail = request.UserEmail,
+                Title = request.Title,
+                Type = request.Type,
+                Content = request.Content,
+                ReferenceId = request.ReferenceId,
+                DeleteId = request.DeleteId,
+            };
+
+            var result = await addNotificationRepository.AddNotificationAsync(notification);
+            await eventBus.PublishAsync(result);
+            return;
+        }
+    }
+}

--- a/src/Notification/Notification.Core/UseCases/Notification/AddNotification/AddNotificationCommandValidator.cs
+++ b/src/Notification/Notification.Core/UseCases/Notification/AddNotification/AddNotificationCommandValidator.cs
@@ -1,0 +1,18 @@
+﻿using FluentValidation;
+
+namespace Planorama.Notification.Core.UseCases.Notification.AddNotification
+{
+    public class AddNotificationCommandValidator : AbstractValidator<AddNotificationCommand>
+    {
+        public AddNotificationCommandValidator() 
+        {
+            RuleFor(x => x.UserId).NotEmpty();
+            RuleFor(x => x.UserEmail).NotEmpty();
+            RuleFor(x => x.Title).NotEmpty();
+            RuleFor(x => x.Type).NotEmpty();
+            RuleFor(x => x.Content).NotEmpty();
+            RuleFor(x => x.ReferenceId).NotEmpty();
+            RuleFor(x => x.DeleteId).NotEmpty();
+        }
+    }
+}

--- a/src/Notification/Notification.Core/UseCases/Notification/AddNotification/IAddNotificationRepository.cs
+++ b/src/Notification/Notification.Core/UseCases/Notification/AddNotification/IAddNotificationRepository.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Planorama.Notification.Core.UseCases.Notification.AddNotification
+{
+    public interface IAddNotificationRepository
+    {
+        Task<NotificationAddedEvent> AddNotificationAsync(Models.Notification notification);
+    }
+}

--- a/src/Notification/Notification.Core/UseCases/Notification/AddNotification/NotificationAddedEvent.cs
+++ b/src/Notification/Notification.Core/UseCases/Notification/AddNotification/NotificationAddedEvent.cs
@@ -1,0 +1,8 @@
+﻿using Planorama.Integration.MessageBroker.Core.Events;
+using Planorama.Notification.Core.Enums;
+using System;
+
+namespace Planorama.Notification.Core.UseCases.Notification.AddNotification
+{
+    public record NotificationAddedEvent(Guid NotificationId, DateTime? DateCreatedUtc, Guid UserId, string UserEmail, string Title, NotificationType Type, string Content, Guid ReferenceId, string DeleteId) : ServiceBusEvent(NotificationId);
+}

--- a/src/Notification/Notification.Infrastructure/Repository/Notification/AddNotificationRepository.cs
+++ b/src/Notification/Notification.Infrastructure/Repository/Notification/AddNotificationRepository.cs
@@ -1,0 +1,23 @@
+﻿using Planorama.Notification.Core.UseCases.Notification.AddNotification;
+using System.Threading.Tasks;
+
+namespace Planorama.Notification.Infrastructure.Repository.Notification
+{
+    public class AddNotificationRepository : IAddNotificationRepository
+    {
+        private readonly NotificationContext context;
+
+        public AddNotificationRepository(NotificationContext context) 
+        {
+            this.context = context;
+        }
+
+        public async Task<NotificationAddedEvent> AddNotificationAsync(Core.Models.Notification notification)
+        {
+            await context.Notifications.AddAsync(notification);
+            var notificationAddedEvent = new NotificationAddedEvent(notification.Id, notification.DateCreatedUtc, notification.UserId, notification.UserEmail, notification.Title, notification.Type, notification.Content, notification.ReferenceId, notification.DeleteId);
+            await context.SaveChangesAsync();
+            return notificationAddedEvent;
+        }
+    }
+}

--- a/src/Notification/Notification.Infrastructure/Startup.cs
+++ b/src/Notification/Notification.Infrastructure/Startup.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Planorama.Notification.Core.UseCases.Notification.AddNotification;
 using Planorama.Notification.Core.UseCases.Notification.GetNotifications;
 using Planorama.Notification.Infrastructure.Repository.Notification;
 using System.Reflection;
@@ -19,6 +20,7 @@ namespace Planorama.Notification.Infrastructure
                     sqlOptions.MigrationsAssembly(typeof(Startup).GetTypeInfo().Assembly.GetName().Name);
                 });
             });
+            services.AddScoped<IAddNotificationRepository, AddNotificationRepository>();
             services.AddScoped<IGetNotificationsRepository, GetNotificationsRepository>();
         }
     }

--- a/src/User/User.Core/UseCases/Authentication/LogoutUser/LogoutUserCommandHandler.cs
+++ b/src/User/User.Core/UseCases/Authentication/LogoutUser/LogoutUserCommandHandler.cs
@@ -2,9 +2,7 @@
 using Planorama.User.Core.Context;
 using Planorama.User.Core.Exceptions;
 using Planorama.User.Core.Services;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/User/User.Core/UseCases/Authentication/RefreshTokens/RefreshTokensCommandHandler.cs
+++ b/src/User/User.Core/UseCases/Authentication/RefreshTokens/RefreshTokensCommandHandler.cs
@@ -24,14 +24,14 @@ namespace Planorama.User.Core.UseCases.Authentication.RefreshTokens
             this.userContext = userContext;
         }
 
-        public async Task Handle(RefreshTokensCommand command, CancellationToken cancellationToken)
+        public async Task Handle(RefreshTokensCommand request, CancellationToken cancellationToken)
         {
             var errors = new Dictionary<string, string[]>();
             if (!userContext.IsLoggedIn())
             {
                 throw new AuthorizationException();
             }
-            var userCredential = await refreshTokensRepository.FindUserCredentialByRefreshTokenAsync(command.RefreshToken);
+            var userCredential = await refreshTokensRepository.FindUserCredentialByRefreshTokenAsync(request.RefreshToken);
             if (userCredential == null)
             {
                 errors.Add("refreshToken", new string[] { "Refresh token is invalid." });

--- a/src/User/User.Core/UseCases/Authentication/RegisterUser/RegisterUserCommandHandler.cs
+++ b/src/User/User.Core/UseCases/Authentication/RegisterUser/RegisterUserCommandHandler.cs
@@ -4,7 +4,6 @@ using Planorama.User.Core.Constants;
 using Planorama.User.Core.Exceptions;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/User/User.Core/UseCases/PrivacySetting/GetPrivacySetting/GetPrivacySettingQueryHandler.cs
+++ b/src/User/User.Core/UseCases/PrivacySetting/GetPrivacySetting/GetPrivacySettingQueryHandler.cs
@@ -1,11 +1,7 @@
 ﻿using MediatR;
 using Planorama.User.Core.Context;
 using Planorama.User.Core.Exceptions;
-using Planorama.User.Core.Models;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/User/User.Core/UseCases/PrivacySetting/UpdatePrivacySetting/IUpdatePrivacySettingRepository.cs
+++ b/src/User/User.Core/UseCases/PrivacySetting/UpdatePrivacySetting/IUpdatePrivacySettingRepository.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Planorama.User.Core.UseCases.PrivacySetting.UpdatePrivacySetting

--- a/src/User/User.Core/UseCases/PrivacySetting/UpdatePrivacySetting/UpdatePrivacySettingCommandHandler.cs
+++ b/src/User/User.Core/UseCases/PrivacySetting/UpdatePrivacySetting/UpdatePrivacySettingCommandHandler.cs
@@ -1,10 +1,7 @@
 ﻿using MediatR;
 using Planorama.User.Core.Context;
 using Planorama.User.Core.Exceptions;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -21,10 +18,10 @@ namespace Planorama.User.Core.UseCases.PrivacySetting.UpdatePrivacySetting
             this.userContext = userContext;
         }
 
-        public async Task Handle(UpdatePrivacySettingCommand command, CancellationToken cancellationToken)
+        public async Task Handle(UpdatePrivacySettingCommand request, CancellationToken cancellationToken)
         {
             var errors = new Dictionary<string, string[]>();
-            var userExists = await updatePrivacySettingRepository.CheckIfUserExists(command.UserId);
+            var userExists = await updatePrivacySettingRepository.CheckIfUserExists(request.UserId);
             if (!userExists)
             {
                 errors.Add("userId", new string[] { "User not found." });
@@ -32,12 +29,12 @@ namespace Planorama.User.Core.UseCases.PrivacySetting.UpdatePrivacySetting
             }
 
             var userId = await updatePrivacySettingRepository.GetUserIdByEmailAsync(userContext.UserName);
-            if (userId != command.UserId)
+            if (userId != request.UserId)
             {
                 throw new AuthorizationException();
             }
 
-            await updatePrivacySettingRepository.UpdatePrivacySettingAsync(command.UserId, command.IsPrivate, userContext.UserName);
+            await updatePrivacySettingRepository.UpdatePrivacySettingAsync(request.UserId, request.IsPrivate, userContext.UserName);
             return;
         }
     }

--- a/tests/Notification/Notification.Core.UnitTests/UseCases/Notification/AddNotificationCommandHandlerUnitTests.cs
+++ b/tests/Notification/Notification.Core.UnitTests/UseCases/Notification/AddNotificationCommandHandlerUnitTests.cs
@@ -1,0 +1,56 @@
+﻿using NSubstitute;
+using Planorama.Integration.MessageBroker.Core.Abstraction;
+using Planorama.Notification.Core.Enums;
+using Planorama.Notification.Core.UseCases.Notification.AddNotification;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Planorama.Notification.Core.UnitTests.UseCases.Notification
+{
+    public class AddNotificationCommandHandlerUnitTests
+    {
+        private readonly AddNotificationCommandHandler addNotificationCommandHandler;
+        private IAddNotificationRepository addNotificationRepositoryMock = Substitute.For<IAddNotificationRepository>();
+        private IEventBus eventBusMock = Substitute.For<IEventBus>();
+
+        public AddNotificationCommandHandlerUnitTests()
+        {
+            addNotificationCommandHandler = new AddNotificationCommandHandler(addNotificationRepositoryMock, eventBusMock);
+        }
+
+        [Fact]
+        public async Task ValidCommand()
+        {
+            //Arrange
+            var command = new AddNotificationCommand(Guid.NewGuid(), "userEmail", "title", NotificationType.SquadInvitation, "content", Guid.NewGuid(), "deleteId");
+            var notificationAddedEvent = new NotificationAddedEvent(Guid.NewGuid(), DateTime.UtcNow, command.UserId, command.UserEmail, command.Title, command.Type, command.Content, command.ReferenceId, command.DeleteId);
+            addNotificationRepositoryMock.AddNotificationAsync(Arg.Any<Models.Notification>()).Returns(Task.FromResult(notificationAddedEvent));
+
+            //Act
+            await addNotificationCommandHandler.Handle(command, CancellationToken.None);
+
+            //Assert
+            await addNotificationRepositoryMock.Received().AddNotificationAsync(Arg.Is<Models.Notification>(x =>
+            x.UserId == command.UserId &&
+            x.UserEmail == command.UserEmail &&
+            x.Title == command.Title &&
+            x.Type == command.Type &&
+            x.Content == command.Content &&
+            x.ReferenceId == command.ReferenceId &&
+            x.DeleteId == command.DeleteId));
+
+            await eventBusMock.Received().PublishAsync(Arg.Is<NotificationAddedEvent>(x =>
+            x.NotificationId == notificationAddedEvent.Id &&
+            x.DateCreatedUtc == notificationAddedEvent.DateCreatedUtc &&
+            x.UserId == notificationAddedEvent.UserId &&
+            x.UserEmail == notificationAddedEvent.UserEmail &&
+            x.Title == notificationAddedEvent.Title &&
+            x.Type == notificationAddedEvent.Type &&
+            x.Content == notificationAddedEvent.Content &&
+            x.ReferenceId == notificationAddedEvent.ReferenceId &&
+            x.DeleteId == notificationAddedEvent.DeleteId));
+        }
+    }
+}

--- a/tests/Notification/Notification.Core.UnitTests/UseCases/Notification/AddNotificationCommandValidatorUnitTests.cs
+++ b/tests/Notification/Notification.Core.UnitTests/UseCases/Notification/AddNotificationCommandValidatorUnitTests.cs
@@ -1,0 +1,40 @@
+﻿using FluentValidation.TestHelper;
+using Planorama.Notification.Core.UseCases.Notification.AddNotification;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Planorama.Notification.Core.UnitTests.UseCases.Notification
+{
+    public class AddNotificationCommandValidatorUnitTests
+    {
+        private readonly AddNotificationCommandValidator validator;
+
+        public AddNotificationCommandValidatorUnitTests()
+        {
+            validator = new AddNotificationCommandValidator();
+        }
+
+        [Fact]
+        public async Task ValidCommand()
+        {
+            var command = new AddNotificationCommand(Guid.NewGuid(), "userEmail", "title", Enums.NotificationType.SquadInvitation, "content", Guid.NewGuid(), "deleteId");
+            var result = await validator.TestValidateAsync(command);
+            result.ShouldNotHaveAnyValidationErrors();
+        }
+
+        [Fact]
+        public async Task InvalidCommand()
+        {
+            var command = new AddNotificationCommand(Guid.Empty, string.Empty, string.Empty, 0, string.Empty, Guid.Empty, string.Empty);
+            var result = await validator.TestValidateAsync(command);
+            result.ShouldHaveValidationErrorFor(x => x.UserId);
+            result.ShouldHaveValidationErrorFor(x => x.UserEmail);
+            result.ShouldHaveValidationErrorFor(x => x.Title);
+            result.ShouldHaveValidationErrorFor(x => x.Type);
+            result.ShouldHaveValidationErrorFor(x => x.Content);
+            result.ShouldHaveValidationErrorFor(x => x.ReferenceId);
+            result.ShouldHaveValidationErrorFor(x => x.DeleteId);
+        }
+    }
+}

--- a/tests/Notification/Notification.Infrastructure.UnitTests/Repository/Notification/AddNotificationRepositoryUnitTests.cs
+++ b/tests/Notification/Notification.Infrastructure.UnitTests/Repository/Notification/AddNotificationRepositoryUnitTests.cs
@@ -1,0 +1,54 @@
+﻿using FizzWare.NBuilder;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Planorama.Notification.Core.Enums;
+using Planorama.Notification.Core.UseCases.Notification.AddNotification;
+using Planorama.Notification.Infrastructure.Repository.Notification;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Planorama.Notification.Infrastructure.UnitTests.Repository.Notification
+{
+    public class AddNotificationRepositoryUnitTests
+    {
+        private readonly NotificationContext context;
+        private AddNotificationRepository addNotificationRepository;
+
+        public AddNotificationRepositoryUnitTests() 
+        {
+            context = Helpers.InMemoryContextHelper.GetContext();
+            addNotificationRepository = new AddNotificationRepository(context);
+        }
+
+        [Fact]
+        public async Task AddNotification()
+        {
+            //Arrange
+            var fakeNotification = Builder<Core.Models.Notification>.CreateNew()
+                .Do(x =>
+                {
+                    x.Id = Guid.NewGuid();
+                    x.DateCreatedUtc = DateTime.UtcNow;
+                    x.UserId = Guid.NewGuid();
+                    x.UserEmail = "user.testing@outlook.com";
+                    x.Title = "title";
+                    x.Type = NotificationType.SquadInvitation;
+                    x.Content = "content";
+                    x.ReferenceId = Guid.NewGuid();
+                    x.DeleteId = "deleteId";
+                })
+                .Build();
+            var expectedEvent = new NotificationAddedEvent(fakeNotification.Id, fakeNotification.DateCreatedUtc, fakeNotification.UserId, fakeNotification.UserEmail, fakeNotification.Title, fakeNotification.Type, fakeNotification.Content, fakeNotification.ReferenceId, fakeNotification.DeleteId);
+            //Act
+            var result = await addNotificationRepository.AddNotificationAsync(fakeNotification);
+
+            //Assert
+            var count = await context.Notifications.CountAsync();
+            Assert.Equal(1, count);
+            Assert.Equal(expectedEvent, result);
+            var notification = await context.Notifications.FindAsync(fakeNotification.Id);
+            notification.Should().BeEquivalentTo(fakeNotification);
+        }
+    }
+}

--- a/tests/User/User.Core.UnitTests/UseCases/Authentication/LoginUserCommandHandlerUnitTests.cs
+++ b/tests/User/User.Core.UnitTests/UseCases/Authentication/LoginUserCommandHandlerUnitTests.cs
@@ -37,7 +37,7 @@ namespace Planorama.User.Core.UnitTests.UseCases.Authentication
             var jwtToken = "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJwbGFub3JhbWEtYXBpIiwiaXNzIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6NTAwMSIsImV4cCI6MTc1NDExMzQwMywianRpIjoiMGZkYWJjNjEtMjBhYi00OGEyLTgyOTQtYzlkMGVhMzIwNmQzIiwic3ViIjoiZmY0Zjk2NzUtNTIwZi00MDgwLTlkYTMtOGMyMzU0Nzg5N2QwIiwibmFtZSI6IkJyaWFuIEdyaWZmaW4iLCJlbWFpbCI6ImJlMTgyYjA4YzNmNDRlMDQ5ZjI2YTg1OEBnbWFpbC5jb20iLCJzY29wZSI6InBsYW5vcmFtYS1hcGkiLCJodHRwOi8vc2NoZW1hcy5taWNyb3NvZnQuY29tL3dzLzIwMDgvMDYvaWRlbnRpdHkvY2xhaW1zL3JvbGUiOiJwbGFub3JhbWEudXNlciIsImlhdCI6MTc1NDEwOTgwMywibmJmIjoxNzU0MTA5ODAzfQ.iytSGvyslmq8r4qTEa6ZtxEoTJ0qy5p0rWCfSLV_NJuJ_0-sjlCfAT_XedzSP8rVZndBX9iAbtzt-o28sYOlgw";
             jwtServiceMock.GenerateJwtToken(Arg.Any<UserCredential>(), Arg.Any<string>(), Arg.Any<IEnumerable<string>>()).Returns((jwtToken, DateTime.UtcNow.AddMinutes(60)));
             jwtServiceMock.GenerateRefreshToken().Returns(userLoggedInEvent.RefreshToken);
-            loginUserRepositoryMock.AddRefreshTokenAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<DateTime>(), Arg.Any<string>()).Returns(userLoggedInEvent);
+            loginUserRepositoryMock.AddRefreshTokenAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<DateTime>(), Arg.Any<string>()).Returns(Task.FromResult(userLoggedInEvent));
             jwtServiceMock.WriteAccessAndRefreshTokensAsHttpOnlyCookie(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTime>());
             jwtServiceMock.WriteAccessAndRefreshTokensAsHttpOnlyCookie(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTime>());
 

--- a/tests/User/User.Core.UnitTests/UseCases/Authentication/RefreshTokensCommandHandlerUnitTests.cs
+++ b/tests/User/User.Core.UnitTests/UseCases/Authentication/RefreshTokensCommandHandlerUnitTests.cs
@@ -42,7 +42,7 @@ namespace Planorama.User.Core.UnitTests.UseCases.Authentication
             var refreshToken = "nvBhkx2Pfm633TYf56by974P0al2JLhjZ1ch324auT6Jn9dIAerWQNJCthZ05KguFymxZ0QBfeeaMP3IlYt1HQ==";
             jwtServiceMock.GenerateRefreshToken().Returns(refreshToken);
             var tokensUpdatedEvent = new TokensUpdatedEvent(userCredential.UserId, refreshToken, DateTime.UtcNow.AddDays(7));
-            refreshTokensRepositoryMock.UpdateRefreshTokenAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<DateTime>(), Arg.Any<string>()).Returns(tokensUpdatedEvent);
+            refreshTokensRepositoryMock.UpdateRefreshTokenAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<DateTime>(), Arg.Any<string>()).Returns(Task.FromResult(tokensUpdatedEvent));
             jwtServiceMock.WriteAccessAndRefreshTokensAsHttpOnlyCookie(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTime>());
             jwtServiceMock.WriteAccessAndRefreshTokensAsHttpOnlyCookie(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<DateTime>());
 

--- a/tests/User/User.Core.UnitTests/UseCases/PrivacySetting/UpdatePrivacySettingCommandHandlerUnitTests.cs
+++ b/tests/User/User.Core.UnitTests/UseCases/PrivacySetting/UpdatePrivacySettingCommandHandlerUnitTests.cs
@@ -29,7 +29,7 @@ namespace Planorama.User.Core.UnitTests.UseCases.PrivacySetting
             userContextMock.UserName.Returns("user.testing@outlook.com");
             updatePrivacySettingRepositoryMock.CheckIfUserExists(Arg.Any<Guid>()).Returns(Task.FromResult(true));
             updatePrivacySettingRepositoryMock.GetUserIdByEmailAsync(Arg.Any<string>()).Returns(command.UserId);
-            updatePrivacySettingRepositoryMock.UpdatePrivacySettingAsync(Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<string>()).Returns(privacySettingUpdatedEvent);
+            updatePrivacySettingRepositoryMock.UpdatePrivacySettingAsync(Arg.Any<Guid>(), Arg.Any<bool>(), Arg.Any<string>()).Returns(Task.FromResult(privacySettingUpdatedEvent));
 
             //Act
             await updatePrivacySettingCommandHandler.Handle(command, CancellationToken.None);


### PR DESCRIPTION
Added AddNotification command handler, repository method, command handler, command validator unit tests and repository unit tests.

The command is triggered when an event that the Notification microservice is subscribed to/listening to is published from another microservice.

Closes #4