### PR TITLE
Bugfix: Revised RefreshTokens POST API to use Refresh token in cookie

### DIFF
--- a/src/User/User.API/Controllers/AuthenticationController.cs
+++ b/src/User/User.API/Controllers/AuthenticationController.cs
@@ -43,10 +43,11 @@ namespace Planorama.User.API.Controllers
             return response;
         }
 
+        [AllowAnonymous]
         [HttpPost("refresh")]
-        public async Task RefreshTokens([FromBody] RefreshTokensRequest model)
+        public async Task RefreshTokens()
         {
-            var request = new RefreshTokensCommand(model.RefreshToken);
+            var request = new RefreshTokensCommand();
             await mediator.Send(request);
         }
 

--- a/src/User/User.API/Models/Authentication/RefreshTokensRequest.cs
+++ b/src/User/User.API/Models/Authentication/RefreshTokensRequest.cs
@@ -1,7 +1,0 @@
-﻿namespace Planorama.User.API.Models.Authentication
-{
-    public class RefreshTokensRequest
-    {
-        public string RefreshToken { get; set; }
-    }
-}

--- a/src/User/User.API/Startup.cs
+++ b/src/User/User.API/Startup.cs
@@ -101,37 +101,40 @@ namespace Planorama.User.API
                     {
                         context.Token = context.Request.Cookies["ACCESS_TOKEN"];
                         return Task.CompletedTask;
+                    },
+                    OnTokenValidated = context =>
+                    {
+                        context.Request.Headers.Remove("Authorization");
+                        return Task.CompletedTask;
                     }
                 };
             });
 
-            services.AddAuthorization(opt =>
-            {
-                opt.AddPolicy(Constants.Policies.UserPolicy, policy =>
+            services.AddAuthorizationBuilder()
+                .AddPolicy(Constants.Policies.UserPolicy, policy =>
                 {
                     policy.RequireAuthenticatedUser();
                     policy.RequireAssertion(c => c.User.Claims.Any(x => x.Type == "scope" && x.Value.Contains("planorama-api")));
                     policy.RequireRole(Roles.UserRole, Roles.MemberRole, Roles.ModeratorRole, Roles.AdminRole);
-                });
-                opt.AddPolicy(Constants.Policies.MemberPolicy, policy =>
+                })
+                .AddPolicy(Constants.Policies.MemberPolicy, policy =>
                 {
                     policy.RequireAuthenticatedUser();
                     policy.RequireAssertion(c => c.User.Claims.Any(x => x.Type == "scope" && x.Value.Contains("planorama-api")));
                     policy.RequireRole(Roles.MemberRole, Roles.ModeratorRole, Roles.AdminRole);
-                });
-                opt.AddPolicy(Constants.Policies.ModeratorPolicy, policy =>
+                })
+                .AddPolicy(Constants.Policies.ModeratorPolicy, policy =>
                 {
                     policy.RequireAuthenticatedUser();
                     policy.RequireAssertion(c => c.User.Claims.Any(x => x.Type == "scope" && x.Value.Contains("planorama-api")));
                     policy.RequireRole(Roles.ModeratorRole, Roles.AdminRole);
-                });
-                opt.AddPolicy(Constants.Policies.AdminPolicy, policy =>
+                })
+                .AddPolicy(Constants.Policies.AdminPolicy, policy =>
                 {
                     policy.RequireAuthenticatedUser();
                     policy.RequireAssertion(c => c.User.Claims.Any(x => x.Type == "scope" && x.Value.Contains("planorama-api")));
                     policy.RequireRole(Roles.AdminRole);
                 });
-            });
 
             services.AddHealthChecks();
             services.AddHttpContextAccessor();

--- a/src/User/User.API/appsettings.json
+++ b/src/User/User.API/appsettings.json
@@ -13,7 +13,7 @@
     "Secret": "a-valid-string-secret-that-is-at-least-512-bits-long-which-is-very-long",
     "Issuer": "https://localhost:5001",
     "Audience": "planorama-api",
-    "ExpirationTimeInMinutes": 60
+    "ExpirationTimeInMinutes": 15
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {

--- a/src/User/User.Core/Services/IJwtService.cs
+++ b/src/User/User.Core/Services/IJwtService.cs
@@ -8,6 +8,6 @@ namespace Planorama.User.Core.Services
         (string jwtToken, DateTime tokenExpiresAtUtc) GenerateJwtToken(Models.UserCredential userCredential, string userFullName, IEnumerable<string> roles);
         string GenerateRefreshToken();
         void WriteAccessAndRefreshTokensAsHttpOnlyCookie(string cookieName, string token, DateTime tokenExpiresAtUtc);
-        void ExpireTokensFromHttpOnlyCookie();
+        void RevokeTokens();
     }
 }

--- a/src/User/User.Core/Services/JwtService.cs
+++ b/src/User/User.Core/Services/JwtService.cs
@@ -73,7 +73,7 @@ namespace Planorama.User.Core.Services
             });
         }
 
-        public void ExpireTokensFromHttpOnlyCookie()
+        public void RevokeTokens()
         {
             foreach(var cookie in httpContextAccessor.HttpContext.Request.Cookies.Keys)
             {

--- a/src/User/User.Core/UseCases/Authentication/LogoutUser/LogoutUserCommandHandler.cs
+++ b/src/User/User.Core/UseCases/Authentication/LogoutUser/LogoutUserCommandHandler.cs
@@ -36,7 +36,7 @@ namespace Planorama.User.Core.UseCases.Authentication.LogoutUser
             {
                 throw new AuthorizationException();
             }
-            jwtService.ExpireTokensFromHttpOnlyCookie();
+            jwtService.RevokeTokens();
             return $"User with Id: {result.Id} successfully logged out.";
         }
     }

--- a/src/User/User.Core/UseCases/Authentication/RefreshTokens/RefreshTokensCommand.cs
+++ b/src/User/User.Core/UseCases/Authentication/RefreshTokens/RefreshTokensCommand.cs
@@ -4,11 +4,5 @@ namespace Planorama.User.Core.UseCases.Authentication.RefreshTokens
 {
     public class RefreshTokensCommand : IRequest
     {
-        public string RefreshToken { get; set; }
-
-        public RefreshTokensCommand(string refreshToken)
-        {
-            RefreshToken = refreshToken;
-        }
     }
 }

--- a/src/User/User.Core/UseCases/Authentication/RefreshTokens/RefreshTokensCommandHandler.cs
+++ b/src/User/User.Core/UseCases/Authentication/RefreshTokens/RefreshTokensCommandHandler.cs
@@ -27,11 +27,12 @@ namespace Planorama.User.Core.UseCases.Authentication.RefreshTokens
         public async Task Handle(RefreshTokensCommand request, CancellationToken cancellationToken)
         {
             var errors = new Dictionary<string, string[]>();
-            if (!userContext.IsLoggedIn())
+            if (string.IsNullOrEmpty(userContext.RefreshToken))
             {
-                throw new AuthorizationException();
+                errors.Add("refreshToken", new string[] { "Refresh token is missing." });
+                throw new RefreshTokenException(errors);
             }
-            var userCredential = await refreshTokensRepository.FindUserCredentialByRefreshTokenAsync(request.RefreshToken);
+            var userCredential = await refreshTokensRepository.FindUserCredentialByRefreshTokenAsync(userContext.RefreshToken);
             if (userCredential == null)
             {
                 errors.Add("refreshToken", new string[] { "Refresh token is invalid." });

--- a/src/User/User.Core/UseCases/Authentication/RefreshTokens/RefreshTokensCommandValidator.cs
+++ b/src/User/User.Core/UseCases/Authentication/RefreshTokens/RefreshTokensCommandValidator.cs
@@ -4,9 +4,5 @@ namespace Planorama.User.Core.UseCases.Authentication.RefreshTokens
 {
     public class RefreshTokensCommandValidator : AbstractValidator<RefreshTokensCommand>
     {
-        public RefreshTokensCommandValidator() 
-        {
-            RuleFor(x => x.RefreshToken).NotEmpty();
-        }
     }
 }

--- a/tests/User/User.API.IntegrationTests/AuthorizationTests.cs
+++ b/tests/User/User.API.IntegrationTests/AuthorizationTests.cs
@@ -24,7 +24,6 @@ namespace Planorama.User.API.IntegrationTests
         }
 
         [Theory]
-        [InlineData("/api/authentication/refresh")]
         [InlineData("/api/authentication/logout")]
         public async Task PostWithNoRoleReturnsForbidden(string url)
         {

--- a/tests/User/User.Core.UnitTests/UseCases/Authentication/LogoutUserCommandHandlerUnitTests.cs
+++ b/tests/User/User.Core.UnitTests/UseCases/Authentication/LogoutUserCommandHandlerUnitTests.cs
@@ -39,7 +39,7 @@ namespace Planorama.User.Core.UnitTests.UseCases.Authentication
             Assert.NotEqual(string.Empty, result);
             await logoutUserRepositoryMock.Received().CheckIfUserCredentialExistsAsync(command.UserId);
             await logoutUserRepositoryMock.Received().ReplaceUserCredentialAsync(command.UserId, "user.testing@outlook.com");
-            jwtServiceMock.Received().ExpireTokensFromHttpOnlyCookie();
+            jwtServiceMock.Received().RevokeTokens();
         }
 
         [Fact]
@@ -53,7 +53,7 @@ namespace Planorama.User.Core.UnitTests.UseCases.Authentication
             await Assert.ThrowsAsync<NotFoundException>(async () => await logoutUserCommandHandler.Handle(command, CancellationToken.None));
             await logoutUserRepositoryMock.Received().CheckIfUserCredentialExistsAsync(command.UserId);
             await logoutUserRepositoryMock.DidNotReceive().ReplaceUserCredentialAsync(Arg.Any<Guid>(), Arg.Any<string>());
-            jwtServiceMock.DidNotReceive().ExpireTokensFromHttpOnlyCookie();
+            jwtServiceMock.DidNotReceive().RevokeTokens();
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace Planorama.User.Core.UnitTests.UseCases.Authentication
             await Assert.ThrowsAsync<AuthorizationException>(async () => await logoutUserCommandHandler.Handle(command, CancellationToken.None));
             await logoutUserRepositoryMock.Received().CheckIfUserCredentialExistsAsync(command.UserId);
             await logoutUserRepositoryMock.Received().ReplaceUserCredentialAsync(command.UserId, "user.testing@outlook.com");
-            jwtServiceMock.DidNotReceive().ExpireTokensFromHttpOnlyCookie();
+            jwtServiceMock.DidNotReceive().RevokeTokens();
         }
     }
 }

--- a/tests/User/User.Core.UnitTests/UseCases/Authentication/RefreshTokensCommandValidatorUnitTests.cs
+++ b/tests/User/User.Core.UnitTests/UseCases/Authentication/RefreshTokensCommandValidatorUnitTests.cs
@@ -17,17 +17,9 @@ namespace Planorama.User.Core.UnitTests.UseCases.Authentication
         [Fact]
         public async Task ValidCommand()
         {
-            var command = new RefreshTokensCommand("WTkh8E7Zgq/l8sqs7yaCUnWXROXyBejV5khykyZlZzoYrGiulKGNqWcwRX5u/WUxWEeXt4M2QeMcImWbw8PlSA==");
+            var command = new RefreshTokensCommand();
             var result = await validator.TestValidateAsync(command);
             result.ShouldNotHaveAnyValidationErrors();
-        }
-
-        [Fact]
-        public async Task InvalidCommand()
-        {
-            var command = new RefreshTokensCommand(string.Empty);
-            var result = await validator.TestValidateAsync(command);
-            result.ShouldHaveValidationErrorFor(x => x.RefreshToken);
         }
     }
 }


### PR DESCRIPTION
Migrated away from using the request payload to send the refresh token to the backend and instead use the refresh token sent from the web client cookie because the cookie is HttpOnly, so it cannot be extracted and accessed by the frontend.

Fixes: #9